### PR TITLE
All functions are ready, and unified output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PyBEAR
 This is the Python SDK for the Westwood Robotics actuator module BEAR (Back-drivable Electromechanical Actuator for Robotics).
 
-Current version: 0.0.5
+Current version: 0.1.0
 
 ### Contact
 Website: www.westwoodrobotics.io

--- a/pybear/Manager.py
+++ b/pybear/Manager.py
@@ -444,8 +444,10 @@ class BEAR(Packet.PKT):
 
         Parameters
         ----------
-        m_ids : tuple of IDs
-        read_registers : tuple of regirsters to read
+        m_ids
+            list of IDs
+        read_registers
+            list of regirsters to read
         """
         return self.bulk_comm(m_ids, read_registers, [], [])
     
@@ -455,14 +457,32 @@ class BEAR(Packet.PKT):
 
         Parameters
         ----------
-        m_ids : tuple of IDs
-        write_registers : tuple of regirsters to write to
-        write_data : tuple of data to write
+        m_ids
+            list of IDs
+        write_registers
+            list of regirsters to write to
+        write_data
+            list of data-list to write [[ID1-data1, ID1-data2 ...],
+                                        [ID2-data1, ID2-data2 ...] ...]
+        ----------
         """
         return self.bulk_comm(m_ids, [], write_registers, write_data)
 
-    def bulk_read_write(self, m_ids, read_reg, write_reg, commands):
+    def bulk_read_write(self, m_ids, read_reg, write_reg, write_data):
         """
         Read up to 16 registers and write to up to 16 registers
+
+        Parameters
+        ----------
+        m_ids
+            list of IDs [ID1, ID2 ...]
+        read_reg
+            list of regirsters to read [reg1, reg2 ...]
+        write_reg
+            list of regirsters to write to [reg1, reg2 ...]
+        write_data
+            list of data-list to write [[ID1-data1, ID1-data2 ...],
+                                        [ID2-data1, ID2-data2 ...] ...]
+        ----------
         """
-        return self.bulk_comm(m_ids, read_reg, write_reg, commands)
+        return self.bulk_comm(m_ids, read_reg, write_reg, write_data)

--- a/pybear/Packet.py
+++ b/pybear/Packet.py
@@ -770,12 +770,15 @@ class PKT(object):
         return retval
 
     def __hex_to_float32(self, val):
-        if len(val) > 4:
-            tmpval = []
-            for idx in range(0, len(val), 4):
-                tmpval.append(struct.unpack('<f', self.sustr_loop_adapt(idx, val))[0])
-        else:
-            tmpval = struct.unpack('<f', self.sustr_adapt(val))[0]
+        # if len(val) > 4:
+        #     tmpval = []
+        #     for idx in range(0, len(val), 4):
+        #         tmpval.append(struct.unpack('<f', self.sustr_loop_adapt(idx, val))[0])
+        # else:
+        #     tmpval = struct.unpack('<f', self.sustr_adapt(val))[0]
+        tmpval = []
+        for idx in range(0, len(val), 4):
+            tmpval.append(struct.unpack('<f', self.sustr_loop_adapt(idx, val))[0])
         return tmpval
 
     def __hex_to_int32(self, val):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ from distutils.core import setup
 
 setup(
         name='PyBEAR',
-        version='0.0.6',
+        version='0.1.0',
         author='Westwood Robotics Corporation',
         author_email='info@westwoodrobotics.io',
         license='Apache License, Version 2.0',


### PR DESCRIPTION
Previously, when output has only one register value, it is in the form of (value, error), but when there are more than one register, the return is ([data], error). It is now all unified to the latter style.

User can also modify timeout and bulk_timeout settings now.